### PR TITLE
Change IndexError to a meaningful error message

### DIFF
--- a/telepresence/proxy/remote.py
+++ b/telepresence/proxy/remote.py
@@ -87,17 +87,18 @@ def get_deployment_json(
                 )
             )
         else:
-            try:
-                # When using a selector we get a list of objects, not just one:
-                return json.loads(
-                    runner.get_output(
-                        runner.kubectl(
-                            get_deployment + ["--selector=telepresence=" + run_id]
-                        ),
-                        stderr=STDOUT
-                    )
-                )["items"][0]
-            except IndexError:
+            # When using a selector we get a list of objects, not just one:
+            deployements = json.loads(
+                runner.get_output(
+                    runner.kubectl(
+                        get_deployment + ["--selector=telepresence=" + run_id]
+                    ),
+                    stderr=STDOUT
+                )
+            )["items"]
+            if deployements.length > 0:
+                return deployements[0]
+            else:
                 raise SystemExit('No deployements found!')
     except CalledProcessError as e:
         raise runner.fail(

--- a/telepresence/proxy/remote.py
+++ b/telepresence/proxy/remote.py
@@ -87,15 +87,18 @@ def get_deployment_json(
                 )
             )
         else:
-            # When using a selector we get a list of objects, not just one:
-            return json.loads(
-                runner.get_output(
-                    runner.kubectl(
-                        get_deployment + ["--selector=telepresence=" + run_id]
-                    ),
-                    stderr=STDOUT
-                )
-            )["items"][0]
+            try:
+                # When using a selector we get a list of objects, not just one:
+                return json.loads(
+                    runner.get_output(
+                        runner.kubectl(
+                            get_deployment + ["--selector=telepresence=" + run_id]
+                        ),
+                        stderr=STDOUT
+                    )
+                )["items"][0]
+            except IndexError:
+                raise SystemExit('No deployements found!')
     except CalledProcessError as e:
         raise runner.fail(
             "Failed to find Deployment '{}':\n{}".format(


### PR DESCRIPTION
When there are no deployements, telepresence crashes with an uncaught IndexError. It should exit with a meaningful error message instead. 

Error message: No Deployements Found